### PR TITLE
fix: Update projects.json docs.sqd.ai

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -1155,7 +1155,7 @@
     "isLiveMainnet": true,
     "isLive": true,
     "name": "SQD",
-    "url": "https://docs.sqd.dev/fuel-indexing/",
+    "url": "https://docs.sqd.ai/fuel-indexing/",
     "tags": [
       "Indexer"
     ],


### PR DESCRIPTION
FE-1474 
Explorer ecosystem tests are not passing since https://docs.sqd.dev/fuel-indexing/ is redirecting to https://docs.sqd.ai/fuel-indexing/